### PR TITLE
Added decompilation for CopyHudToShaded function

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -254,6 +254,9 @@ void RenderAllObjects();
 */
 void PrimitiveAlphaHack(void* param_1, int param_2, int param_3, short colorSpace, int param_5);
 
+/**
+ * @brief Appends generated text objects to the list of HUD mobys. \n Address: 0x80018880
+*/
 void CopyHudToShaded();
 
 /**
@@ -538,6 +541,7 @@ extern int* _ptr_primitivesArray; //0x800757b0                //? Not too sure.
 extern int* _ptr_arrayGraphicsRelatedPointers; //0x8007581c   //? Ptr the the array of primitives structs to be drawn every frame
 extern int _ptrTextUnk; //0x800720f4                          //? Not too sure.
 extern char* _ptr_hudMobys; //0x80075710                      //? A pointer to a dynamic downwards growing array of moby structs to render that gets rendered to the hud every frame.
+extern char* _ptr_hudMobysQueue; //0x800756fc                 //? A pointer to a what seems to be a global queue of moby structs to process. _ptr_hudMobys are added to this.
 
 extern char* _ptr_particleLinkedList; //0x80075738           //? This is a pointer to the next available particle slot.
 

--- a/include/common.h
+++ b/include/common.h
@@ -255,11 +255,6 @@ void RenderAllObjects();
 void PrimitiveAlphaHack(void* param_1, int param_2, int param_3, short colorSpace, int param_5);
 
 /**
- * @brief Appends generated text objects to the list of HUD mobys. \n Address: 0x80018880
-*/
-void CopyHudToShaded();
-
-/**
  * @brief Draws a golden line to the screen \n Address: 0x8001844c
  * @details Fills out a moby struct with the provided coordinate information, and puts it into the _ptr_primitivesArray. Automatically fills out color data, and has it shimmer by using the wobble timer.
 

--- a/mods/functionally_equivalent/asm/copy_hud_to_shaded.s
+++ b/mods/functionally_equivalent/asm/copy_hud_to_shaded.s
@@ -1,0 +1,3 @@
+.set noreorder
+j CopyHudToShaded
+nop

--- a/mods/functionally_equivalent/buildList.txt
+++ b/mods/functionally_equivalent/buildList.txt
@@ -13,7 +13,7 @@ NTSC, exe, 0x80018534, 0x0, asm/draw_arrow.s
 NTSC, exe, 0x8001860C, 0x0, asm/draw_textbox.s
 NTSC, exe, 0x800168DC, 0x0, asm/draw_primitive.s
 NTSC, exe, 0x8002c7bc, 0x0, asm/exit_inventory_menu.s
-
+NTSC, exe, 0x80018880, 0x0, asm/copy_hud_to_shaded.s
 
 NTSC, exe, 0x8008013c, 0x0, asm/gem_home_in_hook.s
 

--- a/mods/functionally_equivalent/include/misc_game.h
+++ b/mods/functionally_equivalent/include/misc_game.h
@@ -31,4 +31,15 @@ int CalculateCompletionPercentage(void);
 */
 int SinScaled(uint param_1);
 
+/**
+ * @brief Appends generated text objects to the list of HUD mobys.
+ * @details
+ * @note Function: CopyHudToShaded \n
+ * Original Address: 0x80018880 \n
+ * Hook File: copy_hud_to_shaded.s \n 
+ * Prototype: misc_game.h \n
+ * Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n 
+*/
+void CopyHudToShaded();
+
 #endif /* MISC_GAME_H */

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -153,4 +153,4 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
   }
   return _ptr_hudMobys;
 }
-/** @} */ // end of reversed_functions
+/** @} */ // end of reveresed_functions

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -153,4 +153,31 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
   }
   return _ptr_hudMobys;
 }
-/** @} */ // end of reveresed_functions
+
+/**
+ * @brief Copies generated moby structs to the end of a global list.
+ * @details Appears to be something that is called often when working with text.
+ 
+ * @note Function: CopyHudToShaded \n
+   Original Address: 0x80018880 \n
+   Hook File: copy_hud_to_shaded.s \n
+   Prototype: n/a \n
+   Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n
+  * @see CopyHudToShaded()
+*/
+void CopyHudToShaded() {
+  char** ref = &_ptr_hudMobys;
+
+  while (*ref != 0) {                                                           // iterate to get to the end of the list.
+    ref += sizeof(MOBY_SIZE);
+  }
+
+  while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                   // append all of the new mobys
+    *ref = _ptr_hudMobys;
+    _ptr_hudMobys += sizeof(MOBY_SIZE);
+    ref += sizeof(MOBY_SIZE);
+  }
+
+  *ref = 0;                                                                     // make sure to set the end of the list to zero for iteration to work on the next call to this function. 
+}
+/** @} */ // end of reversed_functions

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -153,31 +153,4 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
   }
   return _ptr_hudMobys;
 }
-
-/**
- * @brief Copies generated moby structs to the end of a global list.
- * @details Appears to be something that is called often when working with text.
- 
- * @note Function: CopyHudToShaded \n
-   Original Address: 0x80018880 \n
-   Hook File: copy_hud_to_shaded.s \n
-   Prototype: n/a \n
-   Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n
-  * @see CopyHudToShaded()
-*/
-void CopyHudToShaded() {
-  char** ref = &_ptr_hudMobys;
-
-  while (*ref != 0) {                                                           // iterate to get to the end of the list.
-    ref += sizeof(MOBY_SIZE);
-  }
-
-  while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                   // append all of the new mobys
-    *ref = _ptr_hudMobys;
-    _ptr_hudMobys += sizeof(MOBY_SIZE);
-    ref += sizeof(MOBY_SIZE);
-  }
-
-  *ref = 0;                                                                     // make sure to set the end of the list to zero for iteration to work on the next call to this function. 
-}
 /** @} */ // end of reversed_functions

--- a/mods/functionally_equivalent/src/misc_game.c
+++ b/mods/functionally_equivalent/src/misc_game.c
@@ -1,5 +1,6 @@
 #include <common.h>
 #include <custom_types.h>
+#include <moby.h>
 
 /** @ingroup reveresed_functions
  *  @{
@@ -56,5 +57,31 @@ int SinScaled(uint param_1)
   return (int)_sinArray[uVar1];
 }
 
+/**
+ * @brief Copies generated moby structs to the end of a global list.
+ * @details Appears to be something that is called often when working with text.
+ 
+ * @note Function: CopyHudToShaded \n
+   Original Address: 0x80018880 \n
+   Hook File: copy_hud_to_shaded.s \n
+   Prototype: n/a \n
+   Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n
+  * @see CopyHudToShaded()
+*/
+void CopyHudToShaded() {
+  char** ref = &_ptr_hudMobys;
+
+  while (*ref != 0) {                                                           // iterate to get to the end of the list.
+    ref += sizeof(MOBY_SIZE);
+  }
+
+  while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                   // append all of the new mobys
+    *ref = _ptr_hudMobys;
+    _ptr_hudMobys += sizeof(MOBY_SIZE);
+    ref += sizeof(MOBY_SIZE);
+  }
+
+  *ref = 0;                                                                     // make sure to set the end of the list to zero for iteration to work on the next call to this function. 
+}
 
 /** @} */ // end of reveresed_functions

--- a/mods/functionally_equivalent/src/misc_game.c
+++ b/mods/functionally_equivalent/src/misc_game.c
@@ -64,7 +64,7 @@ int SinScaled(uint param_1)
  * @note Function: CopyHudToShaded \n
    Original Address: 0x80018880 \n
    Hook File: copy_hud_to_shaded.s \n
-   Prototype: n/a \n
+   Prototype: misc_game.h \n
    Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n
   * @see CopyHudToShaded()
 */

--- a/symbols/funcs.txt
+++ b/symbols/funcs.txt
@@ -20,7 +20,7 @@ RenderAllObjects = 0x80019698;
 RenderNormalMobys = 0x8001f798;
 RenderShadedMobys = 0x80022a2c;
 
-CopyHudToShaded = 0x80018880;
+CopyHudToShaded_ = 0x80018880;
 
 Vec3Subtract = 0x8001778c;
 Vec3Scale = 0x800177c0;

--- a/symbols/symbols.txt
+++ b/symbols/symbols.txt
@@ -82,6 +82,7 @@ _ptr_levelMobySpecialData = 0x80075930;
 _ptr_particleLinkedList = 0x80075738;
 
 _ptr_hudMobys = 0x80075710;
+_ptr_hudMobysQueue = 0x800756fc;
 
 _ptr_primitivesArray = 0x800757b0;
 _ptr_arrayGraphicsRelatedPointers = 0x8007581c;


### PR DESCRIPTION
Adds decompilation to the previously defined function `CopyHudToShaded`.
Here is the comparison to the original assembly: https://decomp.me/scratch/rbY0g.

This can be tested by exercising any of the functions that prepare text for rendering a few times.
I didn't generate docs because the PR becomes harder to review, but I can certainly do so if you would prefer that.