### PR TITLE
Added decompilation for drawing the demo text function

### DIFF
--- a/include/moby.h
+++ b/include/moby.h
@@ -138,6 +138,14 @@ enum GemColors
 typedef struct HudMobyInfo
 {
     Vec3 position;                  // Coords in hud act different than in world space. X and Y act like 2D plane. Z is effective size in HUD.
+    Vec3 UNK1;
+    byte UNK2[30];
+    short character;
+    byte UNK3[14];
+    byte rotation;
+    byte UNK4[8];
+    byte color;
+    byte UNK5[8];
 }HudMobyInfo;
 
 
@@ -220,6 +228,5 @@ typedef struct Moby
 }Moby;
 
 //* ~~~ Functions ~~~
-
 
 #endif /* MOBY_H */

--- a/mods/functionally_equivalent/asm/draw_demo_text.s
+++ b/mods/functionally_equivalent/asm/draw_demo_text.s
@@ -1,0 +1,3 @@
+.set noreorder
+j DrawDemoText
+nop                 

--- a/mods/functionally_equivalent/buildList.txt
+++ b/mods/functionally_equivalent/buildList.txt
@@ -14,6 +14,7 @@ NTSC, exe, 0x8001860C, 0x0, asm/draw_textbox.s
 NTSC, exe, 0x800168DC, 0x0, asm/draw_primitive.s
 NTSC, exe, 0x8002c7bc, 0x0, asm/exit_inventory_menu.s
 NTSC, exe, 0x80018880, 0x0, asm/copy_hud_to_shaded.s
+NTSC, exe, 0x80018908, 0x0, asm/draw_demo_text.s
 
 NTSC, exe, 0x8008013c, 0x0, asm/gem_home_in_hook.s
 

--- a/mods/functionally_equivalent/include/draw_text.h
+++ b/mods/functionally_equivalent/include/draw_text.h
@@ -36,4 +36,16 @@ char* DrawTextCapitals(char *text,int *textInfo, int spacing, char color);
 */
 int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spacing,char color);
 
+/**
+ * @brief Draws the demo text on the screen.
+ * @details Creates HUD mobys for displaying the text "Demo Mode" with varying size text.
+
+ * @note Function: DrawDemoText \n
+ * Original Address: 0x80018908 \n
+ * Hook File: draw_demo_text.s \n
+ * Prototype: draw_text.h \n
+ * Amount of instructions: MORE IN MODERN GCC (https://decomp.me/scratch/vU390) \n
+*/
+void DrawDemoText();
+
 #endif /* DRAW_TEXT_H */

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -1,5 +1,7 @@
 #include <common.h>
 #include <moby.h>
+#include <vector.h>
+#include <custom_types.h>
 
 /** @ingroup reveresed_functions
  *  @{
@@ -152,5 +154,38 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
     currentCharacter = *text;
   }
   return _ptr_hudMobys;
+}
+
+/**
+ * @brief Draws the demo text on the screen.
+ * @details Creates HUD mobys for displaying the text "Demo Mode" with varying size text.
+ 
+ * @note Function: DrawDemoText \n
+   Original Address: 0x80018908 \n
+   Hook File: draw_demo_text.s \n
+   Prototype: draw_text.h \n
+   Amount of instructions: MORE IN MODERN GCC (https://decomp.me/scratch/vU390) \n
+  * @see DrawDemoText()
+*/
+void DrawDemoText() {
+  const Vec3 capitalTextInfo = { .x = 199, .y = 200, .z = 4352 };
+  const Vec3 lowercaseTextInfo = { .x = 16, .y = 1, .z = 5120 };
+  const byte spacing = 18;
+  const char color = 2;
+  const int sinArrayIncrement = 12;
+
+  HudMobyInfo* mobyPtr = (HudMobyInfo*)_ptr_hudMobys;
+  unsigned int sinArrayIndex = 0;
+  
+  DrawTextAll("DEMO MODE", &capitalTextInfo, &lowercaseTextInfo, spacing, color);
+  mobyPtr--;
+  
+  while (_ptr_hudMobys <= mobyPtr) {
+    mobyPtr->rotation = (byte)(_sinArray[_levelTimer_60fps * 4 + sinArrayIndex & 0xFF] >> 7);
+    mobyPtr--;
+    sinArrayIndex += sinArrayIncrement;
+  }
+
+  CopyHudToShaded();
 }
 /** @} */ // end of reveresed_functions

--- a/symbols/funcs.txt
+++ b/symbols/funcs.txt
@@ -10,6 +10,7 @@ DrawTextCapitals_ = 0x80017FE4;
 DrawTextAll_ = 0x800181AC;
 DrawLine = 0x8001844c;
 DrawPrimitive_ = 0x800168dc;
+DrawDemoText_ = 0x80018908;
 FillScreenColor = 0x800190d4;
 PrimitiveAlphaHack = 0x80060670;
 


### PR DESCRIPTION
This adds the decompilation for the function that draws the text "Demo Mode".
Here is the decompilation comparison (https://decomp.me/scratch/vU390) which shows it as larger unfortunately. I tried to get it smaller, but wasn't able to.