### PR TITLE
Added decompilation for drawing the demo mode text, boot image fade in, and add missing method implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ mods/functionally_equivalent/output/asmvec3_copys.bin
 mods/functionally_equivalent/output/mod_code.bin
 visualizations/inserting into middle of function.drawio
 plugins/__pycache__/plugin.cpython-311.pyc
+plugins/__pycache__/plugin.cpython-310.pyc
 mods/Multi/buildList.txt
 mods/Multi/crash.log
 mods/Multi/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,6 @@ mods/functionally_equivalent/src/draw_stuff.c
 mods/functionally_equivalent/debug/dep/draw_primitive.dep
 mods/functionally_equivalent/debug/obj/draw_primitive.o
 mods/functionally_equivalent/output/asmdraw_primitives.bin
-mods/functionally_equivalent/src/menus.c
 mods/functionally_equivalent/debug/dep/exit_inventory_menu.dep
 mods/functionally_equivalent/debug/dep/menus.dep
 mods/functionally_equivalent/output/asmexit_inventory_menus.bin

--- a/include/common.h
+++ b/include/common.h
@@ -534,9 +534,6 @@ extern int* _ptr_levelMobySpecialData;
 
 extern int* _ptr_primitivesArray; //0x800757b0                //? Not too sure.
 extern int* _ptr_arrayGraphicsRelatedPointers; //0x8007581c   //? Ptr the the array of primitives structs to be drawn every frame
-extern int _ptrTextUnk; //0x800720f4                          //? Not too sure.
-extern char* _ptr_hudMobys; //0x80075710                      //? A pointer to a dynamic downwards growing array of moby structs to render that gets rendered to the hud every frame.
-extern char* _ptr_hudMobysQueue; //0x800756fc                 //? A pointer to a what seems to be a global queue of moby structs to process. _ptr_hudMobys are added to this.
 
 extern char* _ptr_particleLinkedList; //0x80075738           //? This is a pointer to the next available particle slot.
 

--- a/include/moby.h
+++ b/include/moby.h
@@ -221,8 +221,8 @@ typedef struct Moby
 
 //* ~~~ Functions ~~~
 
-extern Moby _ptrTextUnk; //0x800720f4                         //? Not too sure.
-extern char* _ptr_hudMobys; //0x80075710                   //? A pointer to a dynamic downwards growing array of moby structs to render that gets rendered to the hud every frame.
+extern Moby* _ptrTextUnk; //0x800720f4                        //? Not too sure.
+extern Moby* _ptr_hudMobys; //0x80075710                      //? A pointer to a dynamic downwards growing array of moby structs to render that gets rendered to the hud every frame.
 extern Moby* _ptr_hudMobysQueue; //0x800756fc                 //? A pointer to a what seems to be a global queue of moby structs to process. _ptr_hudMobys are added to this.
 extern Moby* _ptr_hudMobysHead; //0x800720f8                  //? A pointer to the head of the HUD mobys queue.
 

--- a/include/moby.h
+++ b/include/moby.h
@@ -221,5 +221,9 @@ typedef struct Moby
 
 //* ~~~ Functions ~~~
 
+extern Moby _ptrTextUnk; //0x800720f4                         //? Not too sure.
+extern char* _ptr_hudMobys; //0x80075710                   //? A pointer to a dynamic downwards growing array of moby structs to render that gets rendered to the hud every frame.
+extern Moby* _ptr_hudMobysQueue; //0x800756fc                 //? A pointer to a what seems to be a global queue of moby structs to process. _ptr_hudMobys are added to this.
+extern Moby* _ptr_hudMobysHead; //0x800720f8                  //? A pointer to the head of the HUD mobys queue.
 
 #endif /* MOBY_H */

--- a/mods/functionally_equivalent/asm/apply_image_fading.s
+++ b/mods/functionally_equivalent/asm/apply_image_fading.s
@@ -1,0 +1,3 @@
+.set noreorder
+j ApplyImageFading
+nop                 

--- a/mods/functionally_equivalent/asm/draw_demo_text.s
+++ b/mods/functionally_equivalent/asm/draw_demo_text.s
@@ -1,0 +1,3 @@
+.set noreorder
+j DrawDemoText
+nop                 

--- a/mods/functionally_equivalent/buildList.txt
+++ b/mods/functionally_equivalent/buildList.txt
@@ -14,6 +14,7 @@ NTSC, exe, 0x8001860C, 0x0, asm/draw_textbox.s
 NTSC, exe, 0x800168DC, 0x0, asm/draw_primitive.s
 NTSC, exe, 0x8002c7bc, 0x0, asm/exit_inventory_menu.s
 NTSC, exe, 0x80018880, 0x0, asm/copy_hud_to_shaded.s
+NTSC, exe, 0x80018908, 0x0, asm/draw_demo_text.s
 
 NTSC, exe, 0x8008013c, 0x0, asm/gem_home_in_hook.s
 

--- a/mods/functionally_equivalent/buildList.txt
+++ b/mods/functionally_equivalent/buildList.txt
@@ -1,6 +1,5 @@
 NTSC, header, 0x80200000, 0x0, src/misc_game.c src/vector.c src/cd.c src/gem_home_in.c src/draw_text.c src/draw_stuff.c src/menus.c, mod_code.bin
 
-
 NTSC, exe, 0x80017758, 0x0, asm/vec3_add.s
 NTSC, exe, 0x80017700, 0x0, asm/vec3_copy.s
 NTSC, exe, 0x80016fd0, 0x0, asm/matrix_transpose_hook.s
@@ -15,6 +14,5 @@ NTSC, exe, 0x800168DC, 0x0, asm/draw_primitive.s
 NTSC, exe, 0x8002c7bc, 0x0, asm/exit_inventory_menu.s
 NTSC, exe, 0x80018880, 0x0, asm/copy_hud_to_shaded.s
 NTSC, exe, 0x80018908, 0x0, asm/draw_demo_text.s
-
+NTSC, exe, 0x80017f24, 0x0, asm/apply_image_fading.s
 NTSC, exe, 0x8008013c, 0x0, asm/gem_home_in_hook.s
-

--- a/mods/functionally_equivalent/include/draw_text.h
+++ b/mods/functionally_equivalent/include/draw_text.h
@@ -36,4 +36,27 @@ char* DrawTextCapitals(char *text,int *textInfo, int spacing, char color);
 */
 int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spacing,char color);
 
+/**
+ * @brief Draws the demo text on the screen.
+ * @details Creates HUD mobys for displaying the text "Demo Mode" with varying size text.
+
+ * @note Function: DrawDemoText \n
+ * Original Address: 0x80018908 \n
+ * Hook File: draw_demo_text.s \n
+ * Prototype: draw_text.h \n
+ * Amount of instructions: MORE IN MODERN GCC (https://decomp.me/scratch/vU390) \n
+*/
+void DrawDemoText();
+
+/**
+ * @brief Appends generated text objects to the list of HUD mobys.
+ * @details
+ * @note Function: CopyHudToShaded \n
+ * Original Address: 0x80018880 \n
+ * Hook File: copy_hud_to_shaded.s \n 
+ * Prototype: misc_game.h \n
+ * Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n 
+*/
+void CopyHudToShaded();
+
 #endif /* DRAW_TEXT_H */

--- a/mods/functionally_equivalent/include/draw_text.h
+++ b/mods/functionally_equivalent/include/draw_text.h
@@ -54,7 +54,7 @@ void DrawDemoText();
  * @note Function: CopyHudToShaded \n
  * Original Address: 0x80018880 \n
  * Hook File: copy_hud_to_shaded.s \n 
- * Prototype: misc_game.h \n
+ * Prototype: draw_text.h \n
  * Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n 
 */
 void CopyHudToShaded();

--- a/mods/functionally_equivalent/include/misc_game.h
+++ b/mods/functionally_equivalent/include/misc_game.h
@@ -42,4 +42,19 @@ int SinScaled(uint param_1);
 */
 void CopyHudToShaded();
 
+/**
+ * @brief Alters the pixels in an image to produce a fade in effect.
+ * @details Decompresses an image and reduces each RGBA pixel's contrast according to a specified value.
+ * @param uint* source - pointer to a compressed image.
+ * @param uint* destination - pointer to the desired destination memory to write the decompressed image.
+ * @param int contrast - strength of dimming to apply to each pixel.
+ * @note Function: ApplyImageFading \n
+   Original Address: 0x80010AA8 \n
+   Hook File: apply_image_fading.s \n
+   Prototype: misc_game.h \n
+   Amount of instructions: Less (https://decomp.me/scratch/S3aIo) \n
+  * @see ApplyImageFading()
+*/
+void ApplyImageFading(uint *source, uint *destination, int contrast);
+
 #endif /* MISC_GAME_H */

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -29,15 +29,15 @@ char* DrawTextCapitals(char *text,int *textInfo, int spacing, char color)
 
   while (currentCharacter != 0) {                                               // Not a NULL terminator
     if (currentCharacter != 0x20) {                                             // Not a space character
-      _ptr_hudMobys -= MOBY_SIZE;                                            // Shifts the moby pointer to a new empty slot
-      memset(_ptr_hudMobys, 0, MOBY_SIZE);                                   // Clears the new slot
-      Vec3Copy((int *)(_ptr_hudMobys + 0xc),textInfo);                       // Copy text x pos, y pos, and size(z pos) to the new moby
+      _ptr_hudMobys -= 1;                                                       // Shifts the moby pointer to a new empty slot
+      memset(_ptr_hudMobys, 0, sizeof(Moby));                                   // Clears the new slot
+      Vec3Copy(&_ptr_hudMobys->position,textInfo);                              // Copy text x pos, y pos, and size(z pos) to the new moby
       currentCharacter = *text;                                                 // Puts each character of the string in currentCharacter each iteration of the loop
       if(currentCharacter - '0' < 10) {                                         // If currentCharacter 0-9
-        *(unsigned short *)(_ptr_hudMobys + 0x36) = currentCharacter + 0xd4;         
+        _ptr_hudMobys->type = currentCharacter + 0xd4;         
       }
       else if(currentCharacter - 'A' < 26) {                                    // If currentCharacter is A-Z
-        *(unsigned short *)(_ptr_hudMobys + 0x36) = currentCharacter + 0x169;        
+        _ptr_hudMobys->type = currentCharacter + 0x169;        
       }
       else {          
         short mobyType;                                                          // Special Characters
@@ -59,11 +59,11 @@ char* DrawTextCapitals(char *text,int *textInfo, int spacing, char color)
         else {                                                                  // Default Character (_)
           mobyType = 0x147;
         }
-        *(short *)(_ptr_hudMobys + 0x36) = mobyType;
+        _ptr_hudMobys->type = mobyType;
       }
-      _ptr_hudMobys[0x47] = 0x7f;
-      _ptr_hudMobys[0x4f] = color;
-      _ptr_hudMobys[0x50] = 0xff;
+      _ptr_hudMobys->requiredHUD1 = 0x7F;
+      _ptr_hudMobys->color = color;
+      _ptr_hudMobys->requiredHUD2 = 0xff;
     }
     text++;                                                                     // Move to next char in String
     textInfo[0] += spacing;                                                     // The x position in the textInfo struct is increased by the spacing amount
@@ -106,42 +106,42 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
       capitalTextInfo[0] += (spaceSize / 4);                                    // Updates X position using spaceSize
     }
     else {
-      _ptr_hudMobys -= MOBY_SIZE;                                               // Shifts the moby pointer to a new empty slot
-      memset(_ptr_hudMobys, '\0', MOBY_SIZE);
-      Vec3Copy((int *)(_ptr_hudMobys + 0xc),capitalTextInfo);
+      _ptr_hudMobys -= 1;                                                       // Shifts the moby pointer to a new empty slot
+      memset(_ptr_hudMobys, '\0', sizeof(Moby));
+      Vec3Copy(&_ptr_hudMobys->position,capitalTextInfo);
       if ((*text == '!') || (*text == '?')) {                                   // If ! or ? then make capital
         isCapital = TRUE;
       }
       if (!isCapital) {
-        *(int *)(_ptr_hudMobys + 0x10) += lowercaseTextInfo[1];                 // Increases the Y position by the "y offset" for lowercase letters
-        *(int *)(_ptr_hudMobys + 0x14) = lowercaseTextInfo[2];                  // sets the size to be the lowercase size
+        _ptr_hudMobys->position.y += lowercaseTextInfo[1];                      // Increases the Y position by the "y offset" for lowercase letters
+        _ptr_hudMobys->position.z = lowercaseTextInfo[2];                       // sets the size to be the lowercase size
       }
       currentCharacter = *text;
       if (currentCharacter - '0' < 10) {                                        // If character is 0-9
-        *(short *)(_ptr_hudMobys + 0x36) = currentCharacter + 0xd4;
+        _ptr_hudMobys->type = currentCharacter + 0xd4;
       }
       else if (currentCharacter - 'A' < 26) {                                   // If character is A-Z
-        *(short *)(_ptr_hudMobys + 0x36) = currentCharacter + 0x169;
+        _ptr_hudMobys->type = currentCharacter + 0x169;
       }
       else if (currentCharacter == '!') {
-        *(short *)(_ptr_hudMobys + 0x36) = 0x4b;                                // Special Characters
+        _ptr_hudMobys->type = 0x4b;                                             // Special Characters
       }
       else if (currentCharacter == ',') {
-        *(short *)(_ptr_hudMobys + 0x36) = 0x4c;
+        _ptr_hudMobys->type = 0x4c;
       }
       else if (currentCharacter == '?') {
-        *(short *)(_ptr_hudMobys + 0x36) = 0x116;
+        _ptr_hudMobys->type = 0x116;
       }
       else if (currentCharacter == '.') {
-        *(short *)(_ptr_hudMobys + 0x36) = 0x147;
+        _ptr_hudMobys->type = 0x147;
       }
       else {                                                                    // Default Case (apostrophe but it's really a comma up in the air lol)
-        *(short *)(_ptr_hudMobys + 0x36) = 0x4c;
-        *(int *)(_ptr_hudMobys + 0x10) -= (*lowercaseTextInfo * 2) / 3;      // Decreases y position (makes it go up) so the comma looks like an apostrophe
+        _ptr_hudMobys->type = 0x4c;
+        _ptr_hudMobys->position.y -= (*lowercaseTextInfo * 2) / 3;              // Decreases y position (makes it go up) so the comma looks like an apostrophe
       }
-      _ptr_hudMobys[0x47] = '\x7f';
-      _ptr_hudMobys[0x4f] = color;
-      _ptr_hudMobys[0x50] = 0xff;
+      _ptr_hudMobys->requiredHUD1 = 0x7F;
+      _ptr_hudMobys->color = color;
+      _ptr_hudMobys->requiredHUD2 = 0xff;
       if (isCapital) {
         *capitalTextInfo += spacing;                                            // If capital increase X position using default spacing
       }
@@ -178,7 +178,7 @@ void CopyHudToShaded() {
 
   while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                 // append all of the new mobys
     *ref = _ptr_hudMobys;
-    _ptr_hudMobys += sizeof(Moby);
+    _ptr_hudMobys += 1;
     ref += 1;
   }
 
@@ -203,7 +203,7 @@ void DrawDemoText() {
   const char color = 2;
   const int sinArrayIncrement = 12;
 
-  Moby* mobyPtr = (Moby*)_ptr_hudMobys;
+  Moby* mobyPtr = _ptr_hudMobys;
   unsigned int sinArrayIndex = 0;
   
   DrawTextAll("DEMO MODE", &capitalTextInfo, &lowercaseTextInfo, spacing, color);

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -163,7 +163,7 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
  * @note Function: CopyHudToShaded \n
    Original Address: 0x80018880 \n
    Hook File: copy_hud_to_shaded.s \n
-   Prototype: misc_game.h \n
+   Prototype: draw_text.h \n
    Amount of instructions: More (https://decomp.me/scratch/rbY0g) \n
   * @see CopyHudToShaded()
 */

--- a/mods/functionally_equivalent/src/draw_text.c
+++ b/mods/functionally_equivalent/src/draw_text.c
@@ -1,5 +1,7 @@
 #include <common.h>
 #include <moby.h>
+#include <vector.h>
+#include <custom_types.h>
 
 /** @ingroup reveresed_functions
  *  @{
@@ -152,5 +154,67 @@ int DrawTextAll(char *text,int *capitalTextInfo,int *lowercaseTextInfo,int spaci
     currentCharacter = *text;
   }
   return _ptr_hudMobys;
+}
+
+/**
+ * @brief Copies generated moby structs to the end of a global list.
+ * @details Appears to be something that is called often when working with text.
+ 
+ * @note Function: CopyHudToShaded \n
+   Original Address: 0x80018880 \n
+   Hook File: copy_hud_to_shaded.s \n
+   Prototype: misc_game.h \n
+   Amount of instructions: More (https://decomp.me/scratch/rbY0g) \n
+  * @see CopyHudToShaded()
+*/
+void CopyHudToShaded() {
+  Moby **entry = &_ptr_hudMobysHead;
+  Moby **ref = &_ptrTextUnk;
+
+  while (*ref != 0) {                                                           // iterate to get to the end of the list.
+    ref = entry;
+    entry = ref + 1;
+  }
+
+  while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                 // append all of the new mobys
+    *ref = _ptr_hudMobys;
+    _ptr_hudMobys += sizeof(Moby);
+    ref += 1;
+  }
+
+  *ref = 0;                                                                     // make sure to set the end of the list to zero for iteration to work on the next call to this function. 
+}
+
+/**
+ * @brief Draws the demo text on the screen.
+ * @details Creates HUD mobys for displaying the text "Demo Mode" with varying size text.
+ 
+ * @note Function: DrawDemoText \n
+   Original Address: 0x80018908 \n
+   Hook File: draw_demo_text.s \n
+   Prototype: draw_text.h \n
+   Amount of instructions: More (https://decomp.me/scratch/vU390) \n
+  * @see DrawDemoText()
+*/
+void DrawDemoText() {
+  const Vec3 capitalTextInfo = { .x = 199, .y = 200, .z = 4352 };
+  const Vec3 lowercaseTextInfo = { .x = 16, .y = 1, .z = 5120 };
+  const byte spacing = 18;
+  const char color = 2;
+  const int sinArrayIncrement = 12;
+
+  Moby* mobyPtr = (Moby*)_ptr_hudMobys;
+  unsigned int sinArrayIndex = 0;
+  
+  DrawTextAll("DEMO MODE", &capitalTextInfo, &lowercaseTextInfo, spacing, color);
+  mobyPtr--;
+  
+  while (_ptr_hudMobys <= mobyPtr) {
+    mobyPtr->rotation.z = _sinArray[_levelTimer_60fps * 4 + sinArrayIndex & 0xFF] >> 7;
+    mobyPtr--;
+    sinArrayIndex += sinArrayIncrement;
+  }
+
+  CopyHudToShaded();
 }
 /** @} */ // end of reveresed_functions

--- a/mods/functionally_equivalent/src/menus.c
+++ b/mods/functionally_equivalent/src/menus.c
@@ -1,0 +1,37 @@
+#include <common.h>
+
+/** @ingroup reveresed_functions
+ *  @{
+ */
+
+/**
+ * @brief Handles the required steps for exiting the inventory menu. 
+ * @details Places texture back into vram, sets gamestate to gameplay, resets hud timers, continues music, etc
+
+ * @note Function: ExitInventoryMenu \n
+ * Original Address: 0x8002c7bc \n
+ * Hook File: exit_inventory_menu.s \n 
+ * Prototype: menus.h \n
+ * Amount of instructions: Same Amount (https://decomp.me/scratch/HuLXz) \n 
+
+*/
+void ExitInventoryMenu(void)
+{
+    RECT screen_rect;
+    
+    screen_rect.x = 0x200;
+    screen_rect.w = 0x100;
+    screen_rect.y = 0;
+    screen_rect.h = 0xe1;
+    LoadImageOrTexture(&screen_rect,(int*)((char*)_maybe_ptr_levelTextureRelated + -0x1c200));
+    DrawSync(0);
+    _gameState = 0;
+    Maybe_ResetHudTimers();
+    _hudChestState = 0;
+    _hudDragonState = 0;
+    _hudLivesState = 0;
+    _hudEggsState = 0;
+    _hudAnimationState = 0;
+    PlayMusicTrack(_musicLevelTrack,8);
+    return;
+}

--- a/mods/functionally_equivalent/src/misc_game.c
+++ b/mods/functionally_equivalent/src/misc_game.c
@@ -57,31 +57,4 @@ int SinScaled(uint param_1)
   return (int)_sinArray[uVar1];
 }
 
-/**
- * @brief Copies generated moby structs to the end of a global list.
- * @details Appears to be something that is called often when working with text.
- 
- * @note Function: CopyHudToShaded \n
-   Original Address: 0x80018880 \n
-   Hook File: copy_hud_to_shaded.s \n
-   Prototype: misc_game.h \n
-   Amount of instructions: Same Amount (https://decomp.me/scratch/rbY0g) \n
-  * @see CopyHudToShaded()
-*/
-void CopyHudToShaded() {
-  char** ref = &_ptr_hudMobys;
-
-  while (*ref != 0) {                                                           // iterate to get to the end of the list.
-    ref += sizeof(MOBY_SIZE);
-  }
-
-  while (_ptr_hudMobys != _ptr_hudMobysQueue) {                                   // append all of the new mobys
-    *ref = _ptr_hudMobys;
-    _ptr_hudMobys += sizeof(MOBY_SIZE);
-    ref += sizeof(MOBY_SIZE);
-  }
-
-  *ref = 0;                                                                     // make sure to set the end of the list to zero for iteration to work on the next call to this function. 
-}
-
 /** @} */ // end of reveresed_functions

--- a/mods/functionally_equivalent/src/misc_game.c
+++ b/mods/functionally_equivalent/src/misc_game.c
@@ -57,4 +57,53 @@ int SinScaled(uint param_1)
   return (int)_sinArray[uVar1];
 }
 
+
+/**
+ * @brief Alters the pixels in an image to produce a fade in effect.
+ * @details Decompresses an image and reduces each RGBA pixel's contrast according to a specified value.
+ * @param uint* source - pointer to a compressed image.
+ * @param uint* destination - pointer to the desired destination memory to write the decompressed image.
+ * @param int contrast - strength of dimming to apply to each pixel.
+ * @note Function: ApplyImageFading \n
+   Original Address: 0x80010AA8 \n
+   Hook File: apply_image_fading.s \n
+   Prototype: misc_game.h \n
+   Amount of instructions: Less (https://decomp.me/scratch/S3aIo) \n
+  * @see ApplyImageFading()
+*/
+void ApplyImageFading(uint *source, uint *destination, int contrast)
+{
+  while( true ) {
+    uint instruction = *source++;
+
+    // If the instruction is invalid, then finish decompressing.
+    if ((int)instruction < 0) {
+      break;
+    }
+
+    // The portion of the instruction on the right side is an offset into the destination memory to start writing to. Maybe some decompression.
+    destination = (uint *)((int)destination + ((instruction << 0x0F) >> 0x0D));
+
+    // The number of RGBA pixels this decompressed segment should take.
+    uint size = instruction >> 0x11;
+    uint *end = destination + size;
+
+    while (destination != end) {
+      uint data = *source++;
+      byte *pixel = (byte*)&data;
+
+      // Apply fading to each byte of the RGBA pixel, but clamp at zero.
+      // This seems to result in less instructions, but is slower.
+      for (uint i = 0; i < sizeof(RGBA_u8); i++) {
+        int applied = (int)pixel[i] + contrast;
+        pixel[i] = applied > 0 ? applied : 0;
+      }
+
+      // Save the modified pixel into the destination buffer.
+      *destination++ = *(uint*)pixel;
+    }
+  }
+}
+
+
 /** @} */ // end of reveresed_functions

--- a/symbols/funcs.txt
+++ b/symbols/funcs.txt
@@ -10,6 +10,7 @@ DrawTextCapitals_ = 0x80017FE4;
 DrawTextAll_ = 0x800181AC;
 DrawLine = 0x8001844c;
 DrawPrimitive_ = 0x800168dc;
+DrawDemoText_ = 0x80018908;
 FillScreenColor = 0x800190d4;
 PrimitiveAlphaHack = 0x80060670;
 

--- a/symbols/funcs.txt
+++ b/symbols/funcs.txt
@@ -54,7 +54,7 @@ maybe_CalculateAngle = 0x800169ac;
 
 Maybe_ResetHudTimers = 0x80058c7c;
 
-
+ApplyImageFading_ = 0x80017f24;
 
 
 CdRead = 0x8006606C;

--- a/symbols/symbols.txt
+++ b/symbols/symbols.txt
@@ -83,6 +83,7 @@ _ptr_particleLinkedList = 0x80075738;
 
 _ptr_hudMobys = 0x80075710;
 _ptr_hudMobysQueue = 0x800756fc;
+_ptr_hudMobysHead = 0x800720f8;
 
 _ptr_primitivesArray = 0x800757b0;
 _ptr_arrayGraphicsRelatedPointers = 0x8007581c;


### PR DESCRIPTION
This adds decompilation for the function that draws the "Demo Mode" text. It also adds decompilation for the boot image fade in.

 I also added the `ExitInventoryMenu` function back in. I think it was excluded by mistake because the file was in the `.gitignore`.